### PR TITLE
Added weighted avg aggregation + migrated to .net core 3.1

### DIFF
--- a/src/Elasticsearch.FSharp/DSL/Aggs.fs
+++ b/src/Elasticsearch.FSharp/DSL/Aggs.fs
@@ -7,6 +7,7 @@ type AggsFieldsBody =
 
 and AggWeightConfig = 
     | WeightField of string
+    | WeightValueField of string
     | Weight of string
 
 and AggParam = 

--- a/src/Elasticsearch.FSharp/DSL/Serialization/Aggs.fs
+++ b/src/Elasticsearch.FSharp/DSL/Serialization/Aggs.fs
@@ -13,6 +13,7 @@ let AggParamsToJSON (aggParams:AggParam list) =
             | AggWeight weightConfig -> 
                 match weightConfig with 
                 | WeightField field -> "\"weight\":{\"field\":\"" + field + "\"}"
+                | WeightValueField field -> "\"value\":{\"field\":\"" + field + "\"}"
                 | Weight weight-> "\"weight\":\"" + weight + "\""
             | AggInterval interval -> "\"interval\":\"" + interval + "\""
             | AggFormat format -> "\"format\":\"" + format + "\""

--- a/src/Elasticsearch.FSharp/Elasticsearch.FSharp.fsproj
+++ b/src/Elasticsearch.FSharp/Elasticsearch.FSharp.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
   
   <PropertyGroup>

--- a/tests/Elasticsearch.FSharp.Tests/Elasticsearch.FSharp.Tests.fsproj
+++ b/tests/Elasticsearch.FSharp.Tests/Elasticsearch.FSharp.Tests.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.2</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/tests/Elasticsearch.FSharp.Tests/Search.fs
+++ b/tests/Elasticsearch.FSharp.Tests/Search.fs
@@ -74,6 +74,24 @@ let ``Aggs serializes correctly``(aggName, aggFieldName) =
     let expected = sprintf """{"aggs":{"%s":{"avg":{"field":"%s"}}}}""" aggName aggFieldName
     let actual = ToJson query
     Assert.AreEqual(expected, actual)
+
+[<Property>]
+let ``Weighted agg serializes correctly``(aggName, aggFieldName, aggValueField) =
+    let query =
+        Search [
+            Aggs [
+                NamedAgg (
+                    aggName, WeightedAvg [
+                        AggWeight (WeightValueField aggValueField)
+                        AggWeight (WeightField aggFieldName)
+                    ]
+                )
+            ]
+        ]
+    let expected = sprintf """{"aggs":{"%s":{"weighted_avg":{"value":{"field":"%s"},"weight":{"field":"%s"}}}}}"""
+                       aggName aggValueField aggFieldName
+    let actual = ToJson query
+    Assert.AreEqual(expected, actual)
     
 [<Property>]
 let ``From serializes correctly``(from) =


### PR DESCRIPTION
Added weighted avg aggregation with `value` field.
```
      "weighted_avg": {
        "value": {
          "field": "grade"
        },
        "weight": {
          "field": "weight"
        }
```