### PR TITLE
Allow to override elastic field name

### DIFF
--- a/src/Elasticsearch.FSharp/Mapping/Attributes.fs
+++ b/src/Elasticsearch.FSharp/Mapping/Attributes.fs
@@ -22,7 +22,8 @@ type ElasticField([<Optional; DefaultParameterValue(null:string)>] fieldType:str
                   [<Optional; DefaultParameterValue(null:string)>] format:string,
                   [<Optional; DefaultParameterValue(false)>] useProperties:bool,
                   [<Optional; DefaultParameterValue(10)>] maxDepth:int,
-                  [<Optional; DefaultParameterValue(false)>] ignoreMalformed:bool) =
+                  [<Optional; DefaultParameterValue(false)>] ignoreMalformed:bool,
+                  [<Optional; DefaultParameterValue(null:string)>] name:string) =
     inherit Attribute()
     
     member val FieldType = fieldType with get
@@ -32,6 +33,7 @@ type ElasticField([<Optional; DefaultParameterValue(null:string)>] fieldType:str
     member val Format = format with get
     member val UseProperties = useProperties with get
     member val MaxDepth = maxDepth with get
+    member val Name = name with get
 
 /// Use this field on attributes of a type that should represent additional `fields` of a field
 [<AttributeUsage(AttributeTargets.Property, AllowMultiple = true)>]
@@ -125,8 +127,13 @@ let rec private getTypePropertyMappings (t: Type) (depth: int) : Dictionary<stri
                 else
                     mapping
             
+            let propName =
+                match elasticFieldAttribute.Name with
+                | null -> prop.Name
+                | name -> name
+            
             if mapping <> PropertyMapping.Default then 
-                result.[prop.Name] <- mapping
+                result.[propName] <- mapping
         | None ->
             ()
     result


### PR DESCRIPTION
This feature allows you to use different field names for mappings in elastic.

```fsharp
[<ElasticType("foo")>]
type Foo = {
  [<ElasticField("text", name = "some_different_name_of_bar")>]
  Bar: string
}
```